### PR TITLE
fix closing backticks

### DIFF
--- a/vignettes/tomato.Rmd
+++ b/vignettes/tomato.Rmd
@@ -266,6 +266,6 @@ map(
   mar = c(0, 0, 0, 0)
 )
 points(long, lat, col = 'red', pch = 16)
- ```
+```
 
 


### PR DESCRIPTION
rmarkdown rendered a warning

```r
In addition: Warning messages:
1: The closing backticks on line 270 (" ```") in file6965536db551.md do not match the opening backticks "```" on line 214. You are recommended to fix either the opening or closing delimiter of the code chunk to use exactly the same numbers of backticks and same level of indentation (or blockquote). 
2: The closing backticks on line 269 (" ```") in tomato.Rmd do not match the opening backticks "```" on line 213. You are recommended to fix either the opening or closing delimiter of the code chunk to use exactly the same numbers of backticks and same level of indentation (or blockquote). 
```